### PR TITLE
Make timer B configurable

### DIFF
--- a/src/gov/nist/javax/sip/TransactionExt.java
+++ b/src/gov/nist/javax/sip/TransactionExt.java
@@ -124,8 +124,8 @@ public interface TransactionExt extends Transaction {
    public void setTimerT4(int interval);
    
    /**
-    * Sets the value of Timer D (in ms)
-    * @param interval value of Timer D (in ms)
+    * Retrieve the value of Timer D (in ms)
+    * @return value of Timer D (in ms)
     * 
     * @since 2.0
     */
@@ -137,4 +137,17 @@ public interface TransactionExt extends Transaction {
     * @since 2.0
     */
    public void setTimerD(int interval);
+
+   /**
+    * Retrieve the value of Timer B (in ms)
+    * @return value of Timer B (in ms)
+    * 
+    */
+   public int getTimerB();
+   /**
+    * Sets the value of Timer B (in ms)
+    * @param interval value of Timer B (in ms)
+    * 
+    */
+   public void setTimerB(int interval);
 }

--- a/src/gov/nist/javax/sip/stack/SIPClientTransactionImpl.java
+++ b/src/gov/nist/javax/sip/stack/SIPClientTransactionImpl.java
@@ -464,7 +464,7 @@ public class SIPClientTransactionImpl extends SIPTransactionImpl implements SIPC
             enableRetransmissionTimer();
           }
           if (isInviteTransaction()) {
-            enableTimeoutTimer(TIMER_B);
+            enableTimeoutTimer(getTimerB());
           } else {
             enableTimeoutTimer(TIMER_F);
           }

--- a/src/gov/nist/javax/sip/stack/SIPTransaction.java
+++ b/src/gov/nist/javax/sip/stack/SIPTransaction.java
@@ -55,11 +55,6 @@ public interface SIPTransaction extends TransactionExt {
    */
   public static final int TIMER_A = 1;
 
-  /**
-   * INVITE transaction timeout timer
-   */
-  public static final int TIMER_B = 64;
-
   public static final int TIMER_J = 64;
 
   public static final int TIMER_F = 64;

--- a/src/gov/nist/javax/sip/stack/SIPTransactionImpl.java
+++ b/src/gov/nist/javax/sip/stack/SIPTransactionImpl.java
@@ -112,6 +112,8 @@ public abstract class SIPTransactionImpl implements SIPTransaction {
 
     protected int timerD = 32000 / baseTimerInterval;
 
+    protected int timerB = 32000 / baseTimerInterval;
+
     // Proposed feature for next release.
     protected transient Object applicationData;
 
@@ -1538,6 +1540,14 @@ public abstract class SIPTransactionImpl implements SIPTransaction {
     }
 
     /**
+     * @see gov.nist.javax.sip.stack.SIPTransaction#getTimerB()
+     */
+    @Override
+    public int getTimerB() {
+        return timerB;
+    }
+
+    /**
      * @see gov.nist.javax.sip.stack.SIPTransaction#setTimerD(int)
      */
     @Override
@@ -1568,6 +1578,17 @@ public abstract class SIPTransactionImpl implements SIPTransaction {
         timerK = T4;
     }
     
+    /**
+     * @see gov.nist.javax.sip.stack.SIPTransaction#setTimerB(int)
+     */
+    @Override
+    public void setTimerB(int interval) {
+        if(interval <= 0) {
+            throw new IllegalArgumentException("Timer B value must be positive!");
+        }
+        timerB = interval / baseTimerInterval;
+    }
+
     /**
      * @see gov.nist.javax.sip.stack.SIPTransaction#getBaseTimerInterval()
      */


### PR DESCRIPTION
For fast failover of an initial INVITE, we want to be able to configure
timer B to a value lower than 32 seconds. This is similar to how
opensips allows you to configure $T_fr_timeout (see
http://opensips.org/pipermail/users/2014-October/030150.html)