### PR TITLE
Fix for JSIP-363: read bytes in UTF8 from input buffer

### DIFF
--- a/src/gov/nist/javax/sip/SipStackImpl.java
+++ b/src/gov/nist/javax/sip/SipStackImpl.java
@@ -65,6 +65,8 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -694,6 +696,14 @@ public class SipStackImpl extends SIPTransactionStack implements
 		this.eventScanner = new EventScanner(this);
 		this.listeningPoints = new Hashtable<String, ListeningPointImpl>();
 		this.sipProviders = Collections.synchronizedList(new LinkedList<SipProviderImpl>());
+		try {
+			Charset charset = Charset.forName("UTF-8");
+			if (charset == null) {
+				throw new UnsupportedCharsetException("Unsupported charset UTF-8");
+			}
+		} catch (Exception e) {
+			logger.logWarning("UTF-8 charset cannot be used this system. This will lead to unpredictable behavior when parsing SIP messages: " + e.getMessage());
+		}
 
 	}
 

--- a/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
+++ b/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
@@ -50,6 +50,7 @@ import gov.nist.javax.sip.stack.SIPTransactionStack;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -98,6 +99,7 @@ public final class PipelinedMsgParser implements Runnable {
     private SIPTransactionStack sipStack;
     private MessageParser smp = null;
     private ConcurrentHashMap<String, CallIDOrderingStructure> messagesOrderingMap = new ConcurrentHashMap<String, CallIDOrderingStructure>();
+    private Charset utf8Charset = Charset.availableCharsets().get("UTF-8");
     boolean isRunning = false;
     
     /**
@@ -459,7 +461,7 @@ public final class PipelinedMsgParser implements Runnable {
                     if (stackLogger.isLoggingEnabled(StackLogger.TRACE_DEBUG)) {
                         stackLogger.logDebug("About to parse : " + inputBuffer.toString());
                     }
-                    sipMessage = smp.parseSIPMessage(inputBuffer.toString().getBytes(), false, false, sipMessageListener);
+                    sipMessage = smp.parseSIPMessage(inputBuffer.toString().getBytes(utf8Charset), false, false, sipMessageListener);
                     if (sipMessage == null) {
                         this.rawInputStream.stopTimer();
                         continue;

--- a/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
+++ b/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
@@ -50,7 +50,6 @@ import gov.nist.javax.sip.stack.SIPTransactionStack;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -99,7 +98,6 @@ public final class PipelinedMsgParser implements Runnable {
     private SIPTransactionStack sipStack;
     private MessageParser smp = null;
     private ConcurrentHashMap<String, CallIDOrderingStructure> messagesOrderingMap = new ConcurrentHashMap<String, CallIDOrderingStructure>();
-    private Charset utf8Charset = Charset.availableCharsets().get("UTF-8");
     boolean isRunning = false;
     
     /**
@@ -461,7 +459,7 @@ public final class PipelinedMsgParser implements Runnable {
                     if (stackLogger.isLoggingEnabled(StackLogger.TRACE_DEBUG)) {
                         stackLogger.logDebug("About to parse : " + inputBuffer.toString());
                     }
-                    sipMessage = smp.parseSIPMessage(inputBuffer.toString().getBytes(utf8Charset), false, false, sipMessageListener);
+                    sipMessage = smp.parseSIPMessage(inputBuffer.toString().getBytes(), false, false, sipMessageListener);
                     if (sipMessage == null) {
                         this.rawInputStream.stopTimer();
                         continue;

--- a/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
+++ b/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
@@ -464,7 +464,7 @@ public final class PipelinedMsgParser implements Runnable {
                     try {
                         inputBufferBytes = inputBuffer.toString().getBytes("UTF-8");
                     } catch (UnsupportedEncodingException e) {
-                        // log the lack of UTF8 support here?
+                        // fall back to default encoding. The lack of UTF8 support has been logged at SIP stack startup
                         inputBufferBytes = inputBuffer.toString().getBytes();
                     }
                     sipMessage = smp.parseSIPMessage(inputBufferBytes, false, false, sipMessageListener);

--- a/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
+++ b/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
@@ -50,6 +50,7 @@ import gov.nist.javax.sip.stack.SIPTransactionStack;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -459,7 +460,14 @@ public final class PipelinedMsgParser implements Runnable {
                     if (stackLogger.isLoggingEnabled(StackLogger.TRACE_DEBUG)) {
                         stackLogger.logDebug("About to parse : " + inputBuffer.toString());
                     }
-                    sipMessage = smp.parseSIPMessage(inputBuffer.toString().getBytes(), false, false, sipMessageListener);
+                    byte[] inputBufferBytes;
+                    try {
+                        inputBufferBytes = inputBuffer.toString().getBytes("UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        // log the lack of UTF8 support here?
+                        inputBufferBytes = inputBuffer.toString().getBytes();
+                    }
+                    sipMessage = smp.parseSIPMessage(inputBufferBytes, false, false, sipMessageListener);
                     if (sipMessage == null) {
                         this.rawInputStream.stopTimer();
                         continue;


### PR DESCRIPTION
UTF8 characters are not handled correctly when receiving a SIP message via TCP or TLS under MS Windows 7.
The problem is caused by the code in PipelinedMsgParser.java in the run() method near line 462.
The bytes are read from buffer inputBuffer.toString().getBytes() without specifying the charset which needs to be UTF8.
This does only work correctly when your local machine is configured to use UTF-8 charset by default.
For MS Windows machines this is not the default.

I would suggest to change the call to inputBuffer.toString().getBytes("UTF-8") and do some error handling for the (strange) case that there is no UTF-8 charset available.

The issue was first reported in https://java.net/jira/browse/JSIP-363. In usnistgov/jsip it has been fixed in a similar way.