### PR TITLE
Pooled timer fixes

### DIFF
--- a/src/gov/nist/javax/sip/stack/timers/AffinitityExecutorSipTimer.java
+++ b/src/gov/nist/javax/sip/stack/timers/AffinitityExecutorSipTimer.java
@@ -139,7 +139,7 @@ public class AffinitityExecutorSipTimer implements SipTimer {
 	 * @see gov.nist.javax.sip.stack.timers.SipTimer#isStarted()
 	 */
 	public boolean isStarted() {
-		return threadPoolExecutor.isTerminated();
+		return !threadPoolExecutor.isShutdown();
 	}
 	
 }

--- a/src/gov/nist/javax/sip/stack/timers/ScheduledExecutorSipTimer.java
+++ b/src/gov/nist/javax/sip/stack/timers/ScheduledExecutorSipTimer.java
@@ -166,7 +166,7 @@ public class ScheduledExecutorSipTimer implements SipTimer {
 	 * @see gov.nist.javax.sip.stack.timers.SipTimer#isStarted()
 	 */
 	public boolean isStarted() {
-		return threadPoolExecutor.isTerminated();
+		return !threadPoolExecutor.isShutdown();
 	}
 	
 }


### PR DESCRIPTION
Without these fixes, the pooled timer implementations always reports themselves as not started and the stack fails to schedule transaction timers on them; switching to them simply breaks the stack.