### PR TITLE
Avoid sending duplicate CRLF keep alive on TCP socket shutdown

### DIFF
--- a/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
@@ -602,7 +602,7 @@ public abstract class ConnectionOrientedMessageChannel extends MessageChannel im
                     int nbytes = myClientInputStream.read(msg, 0, bufferSize);
                     // no more bytes to read...
                     if (nbytes == -1) {
-                        hispipe.write("\r\n\r\n".getBytes("UTF-8"));
+                        hispipe.write("\r\n".getBytes("UTF-8")); // send \r\n to allow the pipe to wake up
                         try {
                             if (sipStack.maxConnections != -1) {
                                 synchronized (messageProcessor) {


### PR DESCRIPTION
The current implementation does send a duplicate CRLF in the case of a TCP/TLS connection shutdown. This leads to the situation that the PipelinedMsgParser handles it as "RFC 5626 CRLF keepalive mechanism" and tries to send a single CRLF. This sending will of course fail because the socket is closed.
Due to a race condition when closing the socket, sometimes this will lead to the error message "A problem occured while trying to send a single CRLF in response to a double CRLF".
