### PR TITLE
Fixed race condition: SocketException due to mySock closed while sending response

### DIFF
--- a/src/gov/nist/javax/sip/stack/TCPMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/TCPMessageChannel.java
@@ -235,6 +235,9 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
        
         Socket sock = null;
         IOException problem = null;
+        // try to prevent at least the worst thread safety issues by using a local variable ...
+        Socket mySockLocal = mySock;
+
         try {
         	sock = this.sipStack.ioHandler.sendBytes(this.messageProcessor.getIpAddress(),
                 this.peerAddress, this.peerPort, this.peerProtocol, msg, isClient, this);
@@ -270,16 +273,16 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
         // if (mySock == null && s != null) {
         // this.uncache();
         // } else
-        if (sock != mySock && sock != null) {
-       	 if (mySock != null) {
+        if (sock != mySockLocal && sock != null) {
+            if (mySockLocal != null) {
        		 if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
        			 logger.logWarning(
                     		 "Old socket different than new socket on channel " + key);
 		             logger.logStackTrace();
 		             logger.logWarning(
-		            		 "Old socket local ip address " + mySock.getLocalSocketAddress());
+		            		 "Old socket local ip address " + mySockLocal.getLocalSocketAddress());
 		             logger.logWarning(
-		            		 "Old socket remote ip address " + mySock.getRemoteSocketAddress());                         
+		            		 "Old socket remote ip address " + mySockLocal.getRemoteSocketAddress());
 		             logger.logWarning(
 		            		 "New socket local ip address " + sock.getLocalSocketAddress());
 		             logger.logWarning(
@@ -288,19 +291,23 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
        		 close(false, false);
        	}    
        	if(problem == null) {
-       		if(mySock != null) {
-	        		if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
-	        			logger.logWarning(
-	                		 "There was no exception for the retry mechanism so creating a new thread based on the new socket for incoming " + key);
-	        		}
-       		}
-	            mySock = sock;
-	            this.myClientInputStream = mySock.getInputStream();
-	            this.myClientOutputStream = mySock.getOutputStream();
-	            Thread thread = new Thread(this);
-	            thread.setDaemon(true);
-	            thread.setName("TCPMessageChannelThread");
-	            thread.start();
+            if (mySockLocal != null) {
+                if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
+                    logger.logWarning(
+                         "There was no exception for the retry mechanism so creating a new thread based on the new socket for incoming " + key);
+                }
+            }
+            // NOTE: need to consider refactoring the whole socket handling with respect to thread safety
+            if (mySockLocal == mySock) {
+                // still not thread safe :-( but what else to do?
+                mySock = sock;
+                this.myClientInputStream = mySock.getInputStream();
+                this.myClientOutputStream = mySock.getOutputStream();
+                Thread thread = new Thread(this);
+                thread.setDaemon(true);
+                thread.setName("TCPMessageChannelThread");
+                thread.start();
+            }
        	} else {
        		if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
        			logger.logWarning(


### PR DESCRIPTION
We have a scenario where a load balancer (Linux Virtual Server - LVS) sends SIP OPTIONS every 5 seconds via TCP.
When receiving this OPTIONS, our application (using this SIP stack) sends 200 OK and the LVS immediately closes the TCP connection after having received it.
Im some cases the socket close is very fast and comes into the TCPMessageChannel while sending the 200 OK in method sendMessage is still in progress.
Unfortunately the socket close will set the mySock member to null while the sendMessage method is still accessing it.
This can happen, because the socket handling is not thread safe.
sendMessage will then run into the situation that it overwrites the mySock with the current send socket sock (line 297).
In our LVS case sock and mySock are the same because LVS puts it's own TCP port into the Via header and no additional TCP connection needs to be established for sending the response.
As a result accessing the overwritten mySock causes a SocketException.

My suggested fix will avoid accessing the live mySock member by making a copy of it in the beginning of sendMessage and checks afterwards, if the copy is still identical to mySock.
This avoids the problem we have but the socket handling is still not thread safe and needs further refactoring in the future.

[sip-race-condition.log](https://github.com/RestComm/jain-sip/files/1711822/sip-race-condition.log)