### PR TITLE
fixed createListeningPoint in case of IOException

### DIFF
--- a/src/gov/nist/javax/sip/SipStackImpl.java
+++ b/src/gov/nist/javax/sip/SipStackImpl.java
@@ -1664,9 +1664,9 @@ public class SipStackImpl extends SIPTransactionStack implements
 				lip = new ListeningPointImpl(this, port, transport);
 				lip.messageProcessor = messageProcessor;
 				messageProcessor.setListeningPoint(lip);
-				this.listeningPoints.put(key, lip);
 				// start processing messages.
 				messageProcessor.start();
+				this.listeningPoints.put(key, lip);
 				return (ListeningPoint) lip;
 			} catch (java.io.IOException ex) {
 				if (logger.isLoggingEnabled())


### PR DESCRIPTION
We have a scenario where binding an IP address fails with IOException in createListeningPoint. The reason for that is that the network device with the given IP address is not there for some reason.
Our application has a mechanismn to retry binding after some time repeatedly because the missing network device will be added after some time and the next try to bind may be successful.
This will not work with the current implementation.
I've found out that the next try to call _createListeningPoint()_ will not fail anymore although the network device is still not there and the IP address is therefore still not bindable. Even in the case where the IP address is bindable on the second try, a bind will not take place and we will end up in a listening point that does not work.
This happens because the implementation of _createListeningPoint()_ stores the key for the listening point to a map called _listeningPoints_ before the bind takes place (in _messageProcessor.start()_). 
An IOExecption will be thrown but the map entry will not be removed. The next time createListeningPoint is called, it will find this map entry to returns it without starting the message processor.

My suggested fix is to store the listening point key to the map after having successfully called the messageProcessor.start() method to avoid having an orphaned entry in the listening points map.