### PR TITLE
fix NameValueList equals, in case this is an empty NameValueList

### DIFF
--- a/src/gov/nist/core/NameValueList.java
+++ b/src/gov/nist/core/NameValueList.java
@@ -153,10 +153,10 @@ public class NameValueList implements Serializable, Cloneable, Map<String,NameVa
         }
         NameValueList other = (NameValueList) otherObject;
 
-        if (this.size() != this.size()) {
+        if (this.size() != other.size()) {
             return false;
         }
-	        Iterator<String> li = this.getNames();
+	    Iterator<String> li = this.getNames();
 	
         while (li.hasNext()) {
             String key = (String) li.next();


### PR DESCRIPTION
Calling NameListValue#equals on a empty NameValueList (handing over another NameValueList) would always return true in the current implementation.

CodeSample:
//Given:
NameValueList a = new NameValueList();
NameValueList b = new NameValueList();
b.set("someName", "someValue");
//When
a.equals(b); --> would be true, but should be false...