### PR TITLE
Address with Text attribute fix. According to the SIP rfc4244 document.

### DIFF
--- a/src/gov/nist/javax/sip/parser/URLParser.java
+++ b/src/gov/nist/javax/sip/parser/URLParser.java
@@ -137,6 +137,7 @@ public class URLParser extends Parser {
                 case '&':
                 case '+':
                 case '$':
+                case '\"':
                     isValidChar = true;
             }
             if (isValidChar || isUnreserved(next)) {

--- a/src/test/unit/gov/nist/javax/sip/parser/AddressParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/AddressParserTest.java
@@ -47,6 +47,8 @@ public class AddressParserTest extends ParserTestCase {
                 "<sip:user@example.com?Route=%3csip:sip.example.com%3e>",
                 "\"M. Ranganathan\"   <sip:mranga@nist.gov>",
                 "<sip:+1-650-555-2222@ss1.wcom.com;user=phone>",
+                "<sip:+1-650-444-2222@ss1.wcom.com;user=phone;Reason=SIP;cause=408;>;index=1",
+                "<sip:+1-650-444-2222@ss1.wcom.com;user=phone;Reason=SIP;cause=408;text=\"Request+Timeout\">;index=1",
                 "M. Ranganathan <sip:mranga@nist.gov>" };
         try {
             for (int i = 0; i < addresses.length; i++) {

--- a/src/test/unit/gov/nist/javax/sip/parser/URLParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/URLParserTest.java
@@ -66,6 +66,8 @@ public class URLParserTest extends TestCase {
           "sip:alice",
           "sip:alice@registrar.com;method=REGISTER",
           "sip:annc@10.10.30.186:6666;early=no;play=http://10.10.30.186:8080/examples/pin.vxml",
+          "sip:+1-650-444-2222@ss1.wcom.com;user=phone;Reason=SIP;cause=408;text=\"Request+Timeout\"",
+          "sip:+1-650-444-2222@ss1.wcom.com;user=phone;Reason=SIP;cause=408",
         "tel:+463-1701-4291" ,
         "tel:46317014291" ,
         "http://10.10.30.186:8080/examples/pin.vxml"


### PR DESCRIPTION
Hi Team, We found a bug inside AddressParser.java when it tries to parse SIP Header with "Text" information.

Here an example from RFC:

<sip:User3@UA3.example.com?Reason=SIP;cause=487;text="Request Terminated">; index=1.1.2,

Please try to run AddressParserTest with these SIP address, you will see the exception.