### PR TITLE
Solve issue #188

### DIFF
--- a/src/gov/nist/javax/sip/stack/NIOHandler.java
+++ b/src/gov/nist/javax/sip/stack/NIOHandler.java
@@ -254,7 +254,6 @@ public class NIOHandler {
         SocketChannel clientSock = null;
         
         boolean entered = false;
-        boolean connected = false;
         boolean attempted = false;
         try {
                 keyedSemaphore.enterIOCriticalSection(key);
@@ -368,7 +367,7 @@ public class NIOHandler {
             }
         } finally {
             if (entered) {
-                if (attempted && !connected) 
+                if (attempted && (clientSock!= null && clientSock.isBlocking() && !clientSock.isConnected()))
                 {
                     // new connection is bad.
                     // remove from our table the socket and its semaphore


### PR DESCRIPTION
Can you please merge this change in NIOHandler ?

The issue is that the 1st SIP re-INVITE from Jain sip going out will fail sending the data:
Dead socketChanneljava.nio.channels.SocketChannel[connected local=/10.3.85.54:55327 remote=/10.5.23.58:5060] socket /10.5.23.58:5060 
