### PR TITLE
Update equality check in HostPort class

### DIFF
--- a/src/gov/nist/core/HostPort.java
+++ b/src/gov/nist/core/HostPort.java
@@ -89,7 +89,7 @@ public final class HostPort extends GenericObject {
             return false;
         }
         HostPort that = (HostPort) other;
-        return port == that.port && host.equals(that.host);
+        return port == this.encode().equals(that.encode());
     }
 
     /** get the Host field


### PR DESCRIPTION
Updated equality check to handle bracketing of IPv6 addresses. "[fe80:1:2:3::4]" is equal to "fe80:1:2:3::4"