### PR TITLE
Improve SIP IPv6 handling by removing scope identifier in host

### DIFF
--- a/src/gov/nist/javax/sip/address/AddressFactoryImpl.java
+++ b/src/gov/nist/javax/sip/address/AddressFactoryImpl.java
@@ -158,10 +158,10 @@ public class AddressFactoryImpl implements AddressFactoryEx {
             uriString.append("@");
         }
 
-        //if host is an IPv6 string we should enclose it in sq brackets
+        //if host is an IPv6 string we should enclose it in sq brackets and remove the scope identifier
         if (host.indexOf(':') != host.lastIndexOf(':')
             && host.trim().charAt(0) != '[')
-            host = '[' + host + ']';
+            host = '[' + host.split("%")[0] + ']';
 
         uriString.append(host);
 


### PR DESCRIPTION
Modified SIP host assignment to remove scope identifier and updated comment to clarify